### PR TITLE
Dockerfile: Expose port 8883, for MQTT over TLS/SSL.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,8 @@ ADD bin/rand_cluster_node.escript /var/lib/vernemq/rand_cluster_node.escript
 EXPOSE \ 
     # MQTT
     1883 \
+    # MQTT/SSL
+    8883 \
     # MQTT WebSockets
     8080 \
     # VerneMQ Message Distribution


### PR DESCRIPTION
Port 8883 is registered for MQTT/SSL (http://mqtt.org/faq), hence it should be exposed by the image in case the broker is exposed through a standard TLS/SSL endpoint.