### PR TITLE
Update vernemq version to 0.15.2 and improved syntax of exposed ports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y \
     sudo \
 && rm -rf /var/lib/apt/lists/*
 
-ENV VERNEMQ_VERSION 0.14.2
+ENV VERNEMQ_VERSION 0.15.2
 
 ADD https://bintray.com/artifact/download/erlio/vernemq/deb/jessie/vernemq_$VERNEMQ_VERSION-1_amd64.deb /tmp/vernemq.deb
 
@@ -19,21 +19,27 @@ ADD files/vm.args /etc/vernemq/vm.args
 ADD bin/vernemq.sh /usr/sbin/start_vernemq
 ADD bin/rand_cluster_node.escript /var/lib/vernemq/rand_cluster_node.escript
 
-EXPOSE \ 
-    # MQTT
-    1883 \
-    # MQTT/SSL
-    8883 \
-    # MQTT WebSockets
-    8080 \
-    # VerneMQ Message Distribution
-    44053 \
-    # EPMD - Erlang Port Mapper Daemon
-    4349 \
-    # Specific Distributed Erlang Port Range 
-    9100 9101 9102 9103 9104 9105 9106 9107 9108 9109 \
-    # Prometheus Metrics
-    8888
+
+# MQTT
+EXPOSE 1883 
+
+# MQTT/SSL
+EXPOSE 8883
+
+# MQTT WebSockets
+EXPOSE 8080
+
+# VerneMQ Message Distribution
+EXPOSE 44053
+
+# EPMD - Erlang Port Mapper Daemon
+EXPOSE 4349
+    
+# Specific Distributed Erlang Port Range 
+EXPOSE 9100 9101 9102 9103 9104 9105 9106 9107 9108 9109
+
+# Prometheus Metrics
+EXPOSE 8888
 
 VOLUME ["/var/log/vernemq", "/var/lib/vernemq", "/etc/vernemq"]
 


### PR DESCRIPTION
Hey guys,

I have update the vernemq version of your docker image.
The image has been tested and is still working as expected. 

Due to the fact that docker told my that the syntax how you've exposed the ports wasn't correct I have updated that as well. The exposed ports haven't been changed. Just the syntax.

Please merge!

Thx in adv.
Michael