### PR TITLE
Support multiple networks

### DIFF
--- a/bin/vernemq.sh
+++ b/bin/vernemq.sh
@@ -2,6 +2,10 @@
 
 IP_ADDRESS=$(ip -4 addr show eth0 | grep -oP "(?<=inet).*(?=/)"| sed -e "s/^[[:space:]]*//" | tail -n 1)
 
+if [ -n ${DOCKER_CUSTOM_VERNEMQ_BIND_ADDRESS} ]; then
+    IP_ADDRESS=${DOCKER_CUSTOM_VERNEMQ_BIND_ADDRESS}
+fi
+
 # Ensure correct ownership and permissions on volumes
 chown vernemq:vernemq /var/lib/vernemq /var/log/vernemq
 chmod 755 /var/lib/vernemq /var/log/vernemq


### PR DESCRIPTION
- added variable DOCKER_CUSTOM_VERNEMQ_BIND_ADDRESS to override the bind address of vernemq
- results in an eaddrinuse error for ranch/metrics, but enables vernemq to run in multiple different networks