### PR TITLE
vernemq.sh: fixed a bug making all ENV var values lowercase in config

### DIFF
--- a/bin/vernemq.sh
+++ b/bin/vernemq.sh
@@ -41,7 +41,7 @@ sed -i '/########## Start ##########/,/########## End ##########/d' /etc/vernemq
 
 echo "########## Start ##########" >> /etc/vernemq/vernemq.conf
 
-env | grep DOCKER_VERNEMQ | grep -v 'DISCOVERY_NODE\|KUBERNETES\|DOCKER_VERNEMQ_USER' | cut -c 16- | tr '[:upper:]' '[:lower:]' | sed 's/__/./g' >> /etc/vernemq/vernemq.conf
+env | grep DOCKER_VERNEMQ | grep -v 'DISCOVERY_NODE\|KUBERNETES\|DOCKER_VERNEMQ_USER' | cut -c 16- | awk '{match($0,/^[A-Z0-9_]*/)}{print tolower(substr($0,RSTART,RLENGTH)) substr($0,RLENGTH+1)}' | sed 's/__/./g' >> /etc/vernemq/vernemq.conf
 
 users_are_set=$(env | grep DOCKER_VERNEMQ_USER)
 if [ ! -z "$users_are_set" ]


### PR DESCRIPTION
Fixes a bug in the init script vernemq.sh that changed all environment variable names and values lowercase. Now only the names are transformed preceding the equals sign.