### PR TITLE
Logging improvements fixing issue #55

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ ENV VERNEMQ_VERSION 1.3.1
 # Defaults
 ENV DOCKER_VERNEMQ_KUBERNETES_NAMESPACE default
 ENV DOCKER_VERNEMQ_KUBERNETES_APP_LABEL vernemq
+ENV DOCKER_VERNEMQ_LOG__CONSOLE console
 
 ADD https://bintray.com/artifact/download/erlio/vernemq/deb/jessie/vernemq_$VERNEMQ_VERSION-1_amd64.deb /tmp/vernemq.deb
 
@@ -27,7 +28,7 @@ ADD bin/rand_cluster_node.escript /var/lib/vernemq/rand_cluster_node.escript
 
 
 # MQTT
-EXPOSE 1883 
+EXPOSE 1883
 
 # MQTT/SSL
 EXPOSE 8883
@@ -40,8 +41,8 @@ EXPOSE 44053
 
 # EPMD - Erlang Port Mapper Daemon
 EXPOSE 4369
-    
-# Specific Distributed Erlang Port Range 
+
+# Specific Distributed Erlang Port Range
 EXPOSE 9100 9101 9102 9103 9104 9105 9106 9107 9108 9109
 
 # Prometheus Metrics
@@ -49,5 +50,5 @@ EXPOSE 8888
 
 VOLUME ["/var/log/vernemq", "/var/lib/vernemq", "/etc/vernemq"]
 
-CMD ["start_vernemq"] 
+CMD ["start_vernemq"]
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ VerneMQ is an Apache2 licensed distributed MQTT broker, developed in Erlang.
 ### Start a VerneMQ cluster node
 
     docker run --name vernemq1 -d erlio/docker-vernemq
-   
+
 Somtimes you need to configure a forwarding for ports (on a Mac for example):
 
     docker run -p 1883:1883 --name vernemq1 -d erlio/docker-vernemq
@@ -23,7 +23,7 @@ Somtimes you need to configure a forwarding for ports (on a Mac for example):
 This starts a new node that listens on 1883 for MQTT connections and on 8080 for MQTT over websocket connections. However, at this moment the broker won't be able to authenticate the connecting clients. To allow anonymous clients use the ```DOCKER_VERNEMQ_ALLOW_ANONYMOUS=on``` environment variable.
 
     docker run -e "DOCKER_VERNEMQ_ALLOW_ANONYMOUS=on" --name vernemq1 -d erlio/docker-vernemq
-    
+
 ### Autojoining a VerneMQ cluster
 
 This allows a newly started container to automatically join a VerneMQ cluster. Assuming you started your first node like the example above you could autojoin the cluster (which currently consists of a single container 'vernemq1') like the following:
@@ -83,7 +83,7 @@ To check if the bove containers have successfully clustered you can issue the ``
     |VerneMQ@172.17.0.151| true  |
     |VerneMQ@172.17.0.152| true  |
     +--------------------+-------+
-    
+
 If you started VerneMQ cluster inside Kubernetes using ```DOCKER_VERNEMQ_DISCOVERY_KUBERNETES=1```, you can execute ```vmq-admin``` through ```kubectl```:
 
     kubectl exec vernemq-0 -- vmq-admin cluster show
@@ -93,7 +93,7 @@ If you started VerneMQ cluster inside Kubernetes using ```DOCKER_VERNEMQ_DISCOVE
     |VerneMQ@vernemq-0.vernemq.default.svc.cluster.local| true  |
     |VerneMQ@vernemq-1.vernemq.default.svc.cluster.local| true  |
     +---------------------------------------------------+-------+
-    
+
 All ```vmq-admin``` commands are available. See https://vernemq.com/docs/administration/ for more information.
 
 ### VerneMQ Configuration
@@ -105,12 +105,20 @@ E.g: `allow_anonymous=on` is `-e "DOCKER_VERNEMQ_ALLOW_ANONYMOUS=on"` or
 `-e "DOCKER_VERNEMQ_ALLOW_REGISTER_DURING_NETSPLIT=on"`. All available configuration
 parameters can be found on https://vernemq.com/docs/configuration/.
 
+#### Logging
+
+VerneMQ sends logs to both stdout and to a log file (`/etc/vernemq/console.log`),
+in production systems using file based logging can lead to issues because logs can
+fill the available disk space and result in system outages. File based logging is
+disabled in the [Dockerfile](Dockerfile) by default, using the environment
+variable `DOCKER_VERNEMQ_LOG__CONSOLE console`.
+
 #### Remarks
 
 Some of our configuration variables contain dots `.`. For example if you want to
 adjust the log level of VerneMQ you'd use `-e
 "DOCKER_VERNEMQ_LOG.CONSOLE.LEVEL=debug"`. However, some container platforms
-such as Kubernetes don't support dots and other special characters in 
+such as Kubernetes don't support dots and other special characters in
 environment variables. If you are on such a platform you could substitute the
 dots with two underscores `__`. The example above would look like `-e
 "DOCKER_VERNEMQ_LOG__CONSOLE__LEVEL=debug"`.

--- a/bin/vernemq.sh
+++ b/bin/vernemq.sh
@@ -108,16 +108,12 @@ sigterm_handler() {
     exit 143; # 128 + 15 -- SIGTERM
 }
 
-# setup handlers
-# on callback, kill the last background process, which is `tail -f /dev/null`
-# and execute the specified handler
-trap 'kill ${!}; siguser1_handler' SIGUSR1
-trap 'kill ${!}; sigterm_handler' SIGTERM
+# Setup OS signal handlers
+trap 'siguser1_handler' SIGUSR1
+trap 'sigterm_handler' SIGTERM
 
-/usr/sbin/vernemq start
+# Start VerneMQ
+/usr/sbin/vernemq console -noshell -noinput $@
 pid=$(ps aux | grep '[b]eam.smp' | awk '{print $2}')
+wait $pid
 
-while true
-do
-    tail -f /var/log/vernemq/console.log & wait ${!}
-done


### PR DESCRIPTION
The console.log file gets rotated and can grow significantly to the
point of making the service deployed using Docker vulnerable to
interruptions due to full hard disk.

- Run VerneMQ in the foreground and stop tailing the console.log file
  will allow `docker logs` command to still work with the stdout.
- Add documentation to explain this issue and how is recommended to
  setup logging in production systems.