### PR TITLE
Fix: Make the kubernetes subdomain optional

### DIFF
--- a/bin/vernemq.sh
+++ b/bin/vernemq.sh
@@ -26,7 +26,11 @@ fi
 if env | grep -q "DOCKER_VERNEMQ_DISCOVERY_KUBERNETES"; then
     # Let's set our nodename correctly
     VERNEMQ_KUBERNETES_SUBDOMAIN=$(curl -X GET $insecure --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt https://kubernetes.default.svc.cluster.local/api/v1/namespaces/$DOCKER_VERNEMQ_KUBERNETES_NAMESPACE/pods?labelSelector=app=$DOCKER_VERNEMQ_KUBERNETES_APP_LABEL -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" | jq '.items[0].spec.subdomain' | sed 's/"//g' | tr '\n' '\0')
-    VERNEMQ_KUBERNETES_HOSTNAME=${MY_POD_NAME}.${VERNEMQ_KUBERNETES_SUBDOMAIN}.${DOCKER_VERNEMQ_KUBERNETES_NAMESPACE}.svc.cluster.local
+    if [ $VERNEMQ_KUBERNETES_SUBDOMAIN == "null" ]; then
+        VERNEMQ_KUBERNETES_HOSTNAME=${MY_POD_NAME}.${VERNEMQ_KUBERNETES_SUBDOMAIN}.${DOCKER_VERNEMQ_KUBERNETES_NAMESPACE}.svc.cluster.local
+    else
+        VERNEMQ_KUBERNETES_HOSTNAME=${MY_POD_NAME}.${DOCKER_VERNEMQ_KUBERNETES_NAMESPACE}.svc.cluster.local
+    fi
 
     sed -i.bak -r "s/VerneMQ@.+/VerneMQ@${VERNEMQ_KUBERNETES_HOSTNAME}/" /etc/vernemq/vm.args
     # Hack into K8S DNS resolution (temporarily)

--- a/bin/vernemq.sh
+++ b/bin/vernemq.sh
@@ -27,9 +27,9 @@ if env | grep -q "DOCKER_VERNEMQ_DISCOVERY_KUBERNETES"; then
     # Let's set our nodename correctly
     VERNEMQ_KUBERNETES_SUBDOMAIN=$(curl -X GET $insecure --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt https://kubernetes.default.svc.cluster.local/api/v1/namespaces/$DOCKER_VERNEMQ_KUBERNETES_NAMESPACE/pods?labelSelector=app=$DOCKER_VERNEMQ_KUBERNETES_APP_LABEL -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" | jq '.items[0].spec.subdomain' | sed 's/"//g' | tr '\n' '\0')
     if [ $VERNEMQ_KUBERNETES_SUBDOMAIN == "null" ]; then
-        VERNEMQ_KUBERNETES_HOSTNAME=${MY_POD_NAME}.${VERNEMQ_KUBERNETES_SUBDOMAIN}.${DOCKER_VERNEMQ_KUBERNETES_NAMESPACE}.svc.cluster.local
-    else
         VERNEMQ_KUBERNETES_HOSTNAME=${MY_POD_NAME}.${DOCKER_VERNEMQ_KUBERNETES_NAMESPACE}.svc.cluster.local
+    else
+        VERNEMQ_KUBERNETES_HOSTNAME=${MY_POD_NAME}.${VERNEMQ_KUBERNETES_SUBDOMAIN}.${DOCKER_VERNEMQ_KUBERNETES_NAMESPACE}.svc.cluster.local
     fi
 
     sed -i.bak -r "s/VerneMQ@.+/VerneMQ@${VERNEMQ_KUBERNETES_HOSTNAME}/" /etc/vernemq/vm.args


### PR DESCRIPTION
Kubernetes subdomains are completely optional according to the
documentation at https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/.
Actually, the subdomain is required here and not having it will result
on the call returning `"null"` when you don't have a subdomain and hence
the hostname ends up being something like `VerneMQ@vernemq-0.null.default.svc.cluster.local`
that causes nodes not able to talk to each other. This fix makes sure to
handle both cases when there is a subdomain or the lack of it.