### PR TITLE
Get kubernetess namespace from the service account secret by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This allows a newly started container to automatically join a VerneMQ cluster. A
 When running VerneMQ inside Kubernetes, it is possible to cause pods matching a specific label to cluster altogether automatically.
 This feature uses Kubernetes' API to discover other peers, and relies on the [default pod service account](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/) which has to be enabled.
 
-Simply set ```DOCKER_VERNEMQ_DISCOVERY_KUBERNETES=1``` in your pod's environment, and expose your own pod name through ```MY_POD_NAME``` . By default, this setting will cause all pods in the ```default``` namespace with the ```app=vernemq``` label to join the same cluster. Namespace and label settings can be overridden with ```DOCKER_VERNEMQ_KUBERNETES_NAMESPACE``` and ```DOCKER_VERNEMQ_KUBERNETES_APP_LABEL```.
+Simply set ```DOCKER_VERNEMQ_DISCOVERY_KUBERNETES=1``` in your pod's environment, and expose your own pod name through ```MY_POD_NAME``` . By default, this setting will cause all pods in the same namespace with the ```app=vernemq``` label to join the same cluster. Namespace and label settings can be overridden with ```DOCKER_VERNEMQ_KUBERNETES_NAMESPACE``` and ```DOCKER_VERNEMQ_KUBERNETES_APP_LABEL```.
 
 An example configuration of your pod's environment looks like this:
 
@@ -48,8 +48,6 @@ An example configuration of your pod's environment looks like this:
         valueFrom:
           fieldRef:
             fieldPath: metadata.name
-      - name: DOCKER_VERNEMQ_KUBERNETES_NAMESPACE
-        value: "mynamespace"
       - name: DOCKER_VERNEMQ_KUBERNETES_APP_LABEL
         value: "myverneinstance"
 

--- a/bin/vernemq.sh
+++ b/bin/vernemq.sh
@@ -24,6 +24,8 @@ if env | grep -q "DOCKER_VERNEMQ_KUBERNETES_INSECURE"; then
 fi
 
 if env | grep -q "DOCKER_VERNEMQ_DISCOVERY_KUBERNETES"; then
+    # Let's get the namespace if it isn't set
+    DOCKER_VERNEMQ_KUBERNETES_NAMESPACE=${DOCKER_VERNEMQ_KUBERNETES_NAMESPACE:-`cat /var/run/secrets/kubernetes.io/serviceaccount/namespace`}
     # Let's set our nodename correctly
     VERNEMQ_KUBERNETES_SUBDOMAIN=$(curl -X GET $insecure --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt https://kubernetes.default.svc.cluster.local/api/v1/namespaces/$DOCKER_VERNEMQ_KUBERNETES_NAMESPACE/pods?labelSelector=app=$DOCKER_VERNEMQ_KUBERNETES_APP_LABEL -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" | jq '.items[0].spec.subdomain' | sed 's/"//g' | tr '\n' '\0')
     if [ $VERNEMQ_KUBERNETES_SUBDOMAIN == "null" ]; then


### PR DESCRIPTION
Fix issue #70, relates to pull request #69
Kubernetes namespace is taken from `/var/run/secrets/kubernetes.io/serviceaccount/namespace` by default. It's still configurable with the environment variable `DOCKER_VERNEMQ_KUBERNETES_NAMESPACE`, no breaking changes.