### PR TITLE
Improve logging documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ parameters can be found on https://vernemq.com/docs/configuration/.
 VerneMQ store crash and error log files in `/var/log/vernemq/`, and, by default, 
 doesn't write console log to the disk to avoid filling the container disk space.
 However this behaviour can be changed by setting the environment variable `DOCKER_VERNEMQ_LOG__CONSOLE` to `both` 
-which tells VerneMQ to send logs to stdout ad `/var/log/vernemq/console.log`.
+which tells VerneMQ to send logs to stdout and `/var/log/vernemq/console.log`.
 For more information please see VerneMQ logging documentation: https://docs.vernemq.com/configuring-vernemq/logging
 
 #### Remarks

--- a/README.md
+++ b/README.md
@@ -105,11 +105,11 @@ parameters can be found on https://vernemq.com/docs/configuration/.
 
 #### Logging
 
-VerneMQ sends logs to both stdout and to a log file (`/etc/vernemq/console.log`),
-in production systems using file based logging can lead to issues because logs can
-fill the available disk space and result in system outages. File based logging is
-disabled in the [Dockerfile](Dockerfile) by default, using the environment
-variable `DOCKER_VERNEMQ_LOG__CONSOLE console`.
+VerneMQ store crash and error log files in `/var/log/vernemq/`, and, by default, 
+doesn't write console log to the disk to avoid filling the container disk space.
+However this behaviour can be changed by setting the environment variable `DOCKER_VERNEMQ_LOG__CONSOLE` to `both` 
+which tells VerneMQ to send logs to stdout ad `/var/log/vernemq/console.log`.
+For more information please see VerneMQ logging documentation: https://docs.vernemq.com/configuring-vernemq/logging
 
 #### Remarks
 


### PR DESCRIPTION
The documentation was pointing to the wrong location of the console log file. The entire paragraph is also rephrased and a link to VerneMQ documentation has been added.

This PR complements a previous PR I submitted to VerneMQ documentation (https://github.com/vernemq/vmq-docs/pull/3)